### PR TITLE
The primary change involves the removal of a package reference from a project file. Specifically, the `Spectre.Console` package, version `0.49.1`, was removed from the `Runid.FileGenerator.csproj` project file. This modification could impact how console output is formatted or managed within the application, depending on how the package was utilized.

### DIFF
--- a/Runid.FileGenerator/Runid.FileGenerator.csproj
+++ b/Runid.FileGenerator/Runid.FileGenerator.csproj
@@ -7,8 +7,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
### Summary of Changes:
- Removed the `Spectre.Console` package (version `0.49.1`) from the `Runid.FileGenerator.csproj`.

Reference to the code change:
- Removal of `<PackageReference Include="Spectre.Console" Version="0.49.1" />` from `Runid.FileGenerator.csproj`.